### PR TITLE
README.md: updated stubs generation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ In order to use [`SoapClient`], you have to activate the following extensions in
 # Generate the SDK
 
 We will use [`wsdl2phpgenerator client`](https://github.com/wsdl2phpgenerator/wsdl2phpgenerator-cli) to generate the LemonWay Stubs:
+## Windows shell
 ```
 php wsdl2phpgenerator-2.5.5.phar -i https://ws.lemonway.fr/mb/YOUR_COMPANY/dev/directkitxml/service.asmx?wsdl -o .\directkitxml -n Directkit
+```
+## *nix shell (Unix, Linux, *BSD, MacOSX)
+```
+php wsdl2phpgenerator-2.5.5.phar -i https://ws.lemonway.fr/mb/YOUR_COMPANY/dev/directkitxml/service.asmx?wsdl -o ./directkitxml -n Directkit
 ```
 this command will generate the PHP classes corespond to all requests / response of the [Lemonway Directkit API] 
 


### PR DESCRIPTION
To make clear the proposed command line uses Windows path syntax, and added a *nix version of the command line.
Using the WIndows version on a *nix shell will result in creating stubs in a `.directkitxml` folder (`\d` being interpreted as `d` by the shell).
